### PR TITLE
python 2/3 compatibility

### DIFF
--- a/cloudy_vision.py
+++ b/cloudy_vision.py
@@ -176,7 +176,7 @@ def process_all_images():
                 copyfile(filepath, output_image_filepath)
 
         # Walk through all vendor APIs to call.
-        for vendor_name, vendor_module in sorted(settings('vendors').iteritems(), reverse=True):
+        for vendor_name, vendor_module in sorted(settings('vendors').items(), reverse=True):
 
             # Figure out filename to store and retrive cached JSON results.
             output_json_filename = filename + "." + vendor_name + ".json"
@@ -257,7 +257,7 @@ def process_all_images():
     # Write HTML output.
     output_html_filepath = os.path.join(settings('output_dir'), 'output.html')
     with open(output_html_filepath, 'w') as output_html_file:
-        output_html_file.write(output_html.encode('utf-8'))
+        output_html_file.write(output_html)
 
 
 if __name__ == "__main__":

--- a/static/template.html
+++ b/static/template.html
@@ -76,7 +76,7 @@
                 </span>
             </td>
           </tr>
-          {% for feature_name, feature_results in vendor['standardized_result'].iteritems() %}
+          {% for feature_name, feature_results in vendor['standardized_result'].items() %}
           <tr>
               <td class="result_name">
                   {{ vendor['vendor_name'] }}_{{ feature_name }}
@@ -135,7 +135,7 @@
                 On time taken, and number of tags returned. Note that Cloudsight returns captions, not a list of tags, so those counts appear as zero.
             </p>
             <table class="u-full-width">
-                {% for vendor, stats in vendor_stats.iteritems() %}
+                {% for vendor, stats in vendor_stats.items() %}
                 {% if loop.first %}
                 <tr class="raw_json">
                     <td class="result_name">Vendor</td>

--- a/vendors/clarifai_.py
+++ b/vendors/clarifai_.py
@@ -23,6 +23,6 @@ def get_standardized_result(api_result):
         tag_names.append(concept['name'])
         tag_scores.append(concept['value'])
 
-    output['tags'] = zip(tag_names, tag_scores)
+    output['tags'] = list(zip(tag_names, tag_scores))
 
     return output


### PR DESCRIPTION
I made changes to make this code both python2 and python3 compatible. I replaced the `iteritems` with `items` - it doesn't do the same thing, but for very small lists (as the ones in this code) performance impact is insignificant. And of course, results are equal.
Also added list in front of `zip` to make in work in python3 (where zip returns a iterable `ZipObject`).